### PR TITLE
Null check before walk to handle null values

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -72,7 +72,7 @@
 
     Iterable.prototype.walk = function(iter) {
       return this.map(function(i) {
-        if ((i.walk != null) && type(i.walk) === "function") {
+        if (type(i != null ? i.walk : void 0) === "function") {
           return i.walk(iter);
         } else {
           return iter(i);

--- a/src/collections.coffee
+++ b/src/collections.coffee
@@ -27,7 +27,7 @@ class Iterable extends Prim
 
 	walk: (iter) -> 
 		@map (i) -> 
-			if i.walk? and type(i.walk) is "function" 
+			if type(i?.walk) is "function"
 				i.walk iter
 			else
 				iter i


### PR DESCRIPTION
I.e. previously
  edn.unify('{:x nil :y ?xxx}', '{:xxx 42}');
was failing due to null not having 'walk' as a member function.
With this change I confirmed the said example works fine.
