### PR TITLE
Add symbol > and < to validRegex for Symbol

### DIFF
--- a/src/atoms.coffee
+++ b/src/atoms.coffee
@@ -41,7 +41,7 @@ class Discard
 	
 class Symbol extends Prim
 
-	validRegex: /[0-9A-Za-z.*+!\-_?$%&=:#/]+/
+	validRegex: /[0-9A-Za-z.*+!\-_?$%&=:#></]+/
 
 	invalidFirstChars: [":", "#", "/"] 
 


### PR DESCRIPTION
For example:

``` Clojure
[:find  ?e1 ?e2  :where [?e1 :age ?a1]  [?e2 :age ?a2]  [(< ?a1 18 ?a2)]]
```

is a valid EDN(such EDN structs are used in Datomic and Datascript).
